### PR TITLE
設定の追加

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -28,12 +28,20 @@
   margin: 3rem 0;
 }
 
+.timer.greenback {
+  background-color: #00ff00;
+}
+
+.timer.blueback {
+  background-color: #0000ff;
+}
+
 .timer .small {
   font-size: 3rem;
 }
 .timer .digit {
   display: inline-block;
-  width: 1ex;
+  width: 0.9ex;
 }
 
 .button-icon {
@@ -52,4 +60,17 @@ a[role="button"] {
 
 .delay-slider {
   vertical-align: middle;
+}
+
+details.settings {
+  margin: 1em;
+  padding: 1ex;
+}
+
+.settings div {
+  margin: 1em 1em;
+}
+
+.settings input {
+  margin-left: 2em;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -36,9 +36,6 @@
   background-color: #0000ff;
 }
 
-.timer .small {
-  font-size: 3rem;
-}
 .timer .digit {
   display: inline-block;
   width: 0.9ex;

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -27,7 +27,6 @@ expected1 =
     , hours = 3
     , minutes = 20
     , seconds = 18
-    , milliSeconds = 729
     }
 
 
@@ -37,5 +36,4 @@ expected2 =
     , hours = 0
     , minutes = 0
     , seconds = 5
-    , milliSeconds = 0
     }


### PR DESCRIPTION
- 背景色
- ~~ミリ秒の表示~~ 

## ミリ秒と秒数表示

-0.500秒という表示は実際のところ正しいのだが、秒だけで見たときに -1, -0, 0, 1 というカウントになってしまう。
また、ミリ秒を追加しても0秒の時点を合わせるのが難しい。
そのため、ミリ秒表示は削除し、-1, 0, 1 と遷移するようにした。