### PR TITLE
Browser.element に実装を変更する

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -10,8 +10,9 @@
 }
 
 /* Customize Pico CSS */
-:root {
-  --spacing: 1ex;
+body > header,
+body > main {
+  --block-spacing-vertical: calc(var(--spacing) * 1);
 }
 
 /*

--- a/css/main.scss
+++ b/css/main.scss
@@ -9,6 +9,11 @@
   height: inherit;
 }
 
+/* Customize Pico CSS */
+:root {
+  --spacing: 1ex;
+}
+
 /*
  * "D-DIN" is licensed under the SIL Open Font License 1.1
  * https://www.1001fonts.com/d-din-font.html
@@ -26,25 +31,23 @@
   text-align: center;
   padding: 3rem 0;
   margin: 1rem 0;
-}
 
-.timer.greenback {
-  background-color: #00ff00;
-}
+  &.greenback {
+    background-color: #00ff00;
+  }
+  &.blueback {
+    background-color: #0000ff;
+  }
 
-.timer.blueback {
-  background-color: #0000ff;
-}
-
-.timer .digit {
-  display: inline-block;
-  width: 1ex;
-  vertical-align: middle;
-}
-
-.timer .sep {
-  display: inline-block;
-  width: 0.5ex;
+  .digit {
+    display: inline-block;
+    width: 1ex;
+    vertical-align: middle;
+  }
+  .sep {
+    display: inline-block;
+    width: 0.5ex;
+  }
 }
 
 .button-icon {
@@ -55,6 +58,13 @@ footer {
   margin-top: 1rem;
   background-color: #eeeeee;
   text-align: center;
+
+  h2 {
+    margin-bottom: 1ex;
+  }
+  #introduce-request {
+    background-color: white;
+  }
 }
 .footer-left {
   text-align: left;
@@ -63,24 +73,10 @@ footer {
   text-align: left;
 }
 
-footer h2 {
-  margin-bottom: 1ex;
-}
-
-footer #introduce-request {
-  background-color: white;
-}
-
 a[role="button"] {
   margin-left: 1ex;
   margin-right: 1ex;
 }
-
-/*
-.delay-slider {
-  margin: auto 0;
-}
-*/
 
 .controls {
   margin: auto 0;
@@ -91,14 +87,14 @@ a[role="button"] {
   border: 1px solid #a2afb9;
   border-radius: 5px;
   padding: 1ex;
-}
 
-.settings > div {
-  margin: 1em 3em;
-}
+  > div {
+    margin: 1em 3em;
+  }
 
-.settings input[type="radio"] {
-  margin-left: 2em;
+  input[type="radio"] {
+    margin-left: 2em;
+  }
 }
 
 .bgColor label {

--- a/index.html
+++ b/index.html
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
 <html lang="ja" data-theme="light" prefix="og: https://ogp.me/ns#">
   <head>
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5262330257175244"
-     crossorigin="anonymous"></script>
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5262330257175244"
+      crossorigin="anonymous"
+    ></script>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <meta
@@ -60,7 +63,85 @@
   </head>
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>
+    <header>
+      <nav class="container">
+        <ul>
+          <li><strong style="font-size: xx-large">SyncTimer</strong></li>
+        </ul>
+        <ul>
+          <li>
+            <a href="/about/?utm_source=top" class="outline" role="button"
+              >SyncTimerとは？</a
+            >
+          </li>
+        </ul>
+      </nav>
+    </header>
     <div id="root"></div>
+    <footer>
+      <div class="container">
+        <p>
+          機能要望や質問・感想などは<a
+            href="https://docs.google.com/forms/d/e/1FAIpQLSfgmFqq-t-vv6gC1YpgoH3nCK1b7gI0ROC25K1NX9r5jGtndg/viewform?usp=sf_link"
+            target="_blank"
+            rel="noopener noreferrer"
+            >こちらのフォームからどうぞ</a
+          >
+        </p>
+        <div>
+          <small
+            >よろしければ概要欄でタイマーの紹介をお願いします（必須ではありません）</small
+          >
+        </div>
+        <textarea
+          name="introduce-request"
+          id="introduce-request"
+          rows="2"
+          readonly
+        >
+同時視聴用タイマー SyncTimer を利用しています
+https://sync-timer.netlify.app/
+        </textarea>
+        <div class="grid">
+          <div class="footer-left">
+            <h2>更新情報</h2>
+            <ul>
+              <li>2022-11-18 時間の表示をON/OFFできるようにしました</li>
+              <li>2022-11-14 YouTubeでの利用例を紹介しました</li>
+            </ul>
+          </div>
+          <div class="footer-right">
+            <div>
+              <a
+                href="https://youtube.com/playlist?list=PLzz5NMXBDKoZ8UoGCgQI9mdcfmyjugbwz"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><i class="fab fa-youtube button-icon"></i>YouTubeでの利用例</a
+              >
+            </div>
+            <div>
+              <a
+                href="https://twitter.com/intent/user?user_id=62148177"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><i class="fab fa-twitter button-icon"></i>@mather314
+                (開発者)</a
+              >
+            </div>
+            <div>
+              <a
+                href="https://github.com/mather/sync-timer"
+                class="secondary"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><i class="fab fa-github button-icon"></i>mather/sync-timer</a
+              >
+            </div>
+            <div>© Eisuke Kuwahata</div>
+          </div>
+        </div>
+      </div>
+    </footer>
     <script async src="./js/index.js" type="module"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -70,6 +70,11 @@
         </ul>
         <ul>
           <li>
+            <a href="https://twitter.com/hashtag/sync_timer?f=live"
+              ><i class="fab fa-twitter"></i>#sync_timer</a
+            >
+          </li>
+          <li>
             <a href="/about/?utm_source=top" class="outline" role="button"
               >SyncTimerとは？</a
             >

--- a/index.html
+++ b/index.html
@@ -77,7 +77,9 @@
         </ul>
       </nav>
     </header>
-    <div id="root"></div>
+    <main>
+      <div id="root"></div>
+    </main>
     <footer>
       <div class="container">
         <p>

--- a/js/index.js
+++ b/js/index.js
@@ -34,7 +34,6 @@ const app = Elm.Main.init({
 });
 
 app.ports.setQueryString.subscribe((newQS) => {
-  console.debug(newQS);
   const currentUrl = new URL(document.location);
   const newUrl = currentUrl.origin + currentUrl.pathname + newQS;
   window.history.replaceState(null, "", newUrl);

--- a/js/index.js
+++ b/js/index.js
@@ -6,9 +6,39 @@ import "@fortawesome/fontawesome-free/css/brands.css";
 import "@fortawesome/fontawesome-free/css/solid.css";
 import "../css/main.css";
 
+const searchParams = (new URL(document.location)).searchParams;
+const parseFg = (s) => {
+  if (!s) return null;
+  const re = /^#[0-9a-f]{6}$/;
+  if (re.test(s)) return s;
+  return null;
+}
+const parseInit = (s) => {
+  if (s) {
+    const n = parseInt(s, 10);
+    if (n > 30 || n < -30) return null;
+    return n;
+  }
+  return null;
+}
+const flags = {
+  fg: parseFg(searchParams.get("fg")),
+  bg: searchParams.get("bg"),
+  init: parseInit(searchParams.get("init")),
+  h: searchParams.get("h")
+};
+
 const app = Elm.Main.init({
   node: document.getElementById("root"),
+  flags: flags
 });
+
+app.ports.setQueryString.subscribe((newQS) => {
+  console.debug(newQS);
+  const currentUrl = new URL(document.location);
+  const newUrl = currentUrl.origin + currentUrl.pathname + newQS;
+  window.history.replaceState(null, "", newUrl);
+})
 
 app.ports.sendAnalyticsEvent.subscribe((event) => {
   const { category, action, label, value } = JSON.parse(event);

--- a/js/index.js
+++ b/js/index.js
@@ -4,7 +4,7 @@ import "@picocss/pico/css/pico.css";
 import "@fortawesome/fontawesome-free/css/fontawesome.css";
 import "@fortawesome/fontawesome-free/css/brands.css";
 import "@fortawesome/fontawesome-free/css/solid.css";
-import "../css/main.css";
+import "../css/main.scss";
 
 const searchParams = (new URL(document.location)).searchParams;
 const parseFg = (s) => {

--- a/js/index.js
+++ b/js/index.js
@@ -6,31 +6,33 @@ import "@fortawesome/fontawesome-free/css/brands.css";
 import "@fortawesome/fontawesome-free/css/solid.css";
 import "../css/main.scss";
 
-const searchParams = (new URL(document.location)).searchParams;
-const parseFg = (s) => {
-  if (!s) return null;
-  const re = /^#[0-9a-f]{6}$/;
-  if (re.test(s)) return s;
-  return null;
-}
-const parseInit = (s) => {
-  if (s) {
-    const n = parseInt(s, 10);
-    if (n > 30 || n < -30) return null;
-    return n;
+const parseParams = () => {
+  const searchParams = (new URL(document.location)).searchParams;
+  const parseFg = (s) => {
+    if (!s) return null;
+    const re = /^#[0-9a-f]{6}$/;
+    if (re.test(s)) return s;
+    return null;
   }
-  return null;
-}
-const flags = {
-  fg: parseFg(searchParams.get("fg")),
-  bg: searchParams.get("bg"),
-  init: parseInit(searchParams.get("init")),
-  h: searchParams.get("h")
+  const parseInit = (s) => {
+    if (s) {
+      const n = parseInt(s, 10);
+      if (n > 30 || n < -30) return null;
+      return n;
+    }
+    return null;
+  }
+  return {
+    fg: parseFg(searchParams.get("fg")),
+    bg: searchParams.get("bg"),
+    init: parseInit(searchParams.get("init")),
+    h: searchParams.get("h")
+  };
 };
 
 const app = Elm.Main.init({
   node: document.getElementById("root"),
-  flags: flags
+  flags: parseParams()
 });
 
 app.ports.setQueryString.subscribe((newQS) => {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "elm-hot": "^1.1.6",
     "elm-test": "^0.19.1-revision10",
     "node-elm-compiler": "^5.0.6",
+    "sass": "^1.56.1",
     "vite": "^2.9.13",
     "vite-plugin-elm": "^2.5.1"
   },

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,7 +3,7 @@ port module Main exposing (DisplayTime, main, millisToDisplayTime)
 import Browser exposing (UrlRequest)
 import Browser.Navigation
 import Dict
-import Html exposing (Attribute, Html, a, button, details, div, fieldset, i, input, label, legend, main_, span, summary, text)
+import Html exposing (Attribute, Html, a, button, details, div, fieldset, i, input, label, legend, span, summary, text)
 import Html.Attributes as A exposing (attribute, checked, class, for, href, id, name, step, style, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Json.Encode as E
@@ -225,7 +225,7 @@ update msg ({ setting } as model) =
 
 view : Model -> Html Msg
 view model =
-    main_ [ class "container" ]
+    div [ class "container" ]
         [ viewTimer model
         , viewTimerSettings model.setting
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,14 +1,12 @@
 port module Main exposing (DisplayTime, main, millisToDisplayTime)
 
-import Browser exposing (UrlRequest)
-import Browser.Navigation
+import Browser
 import Dict
 import Html exposing (Attribute, Html, a, button, details, div, fieldset, i, input, label, legend, span, summary, text)
-import Html.Attributes as A exposing (attribute, checked, class, for, href, id, name, step, style, type_, value)
+import Html.Attributes as A exposing (attribute, checked, class, for, id, name, step, style, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Json.Encode as E
 import Time
-import Url
 import Url.Builder as UB
 
 
@@ -156,7 +154,6 @@ type Msg
     | SetBgColor BgColor
     | SetFgColor String
     | ToggleShowHour
-    | LinkClicked UrlRequest
     | NoOp
 
 
@@ -210,14 +207,6 @@ update msg ({ setting } as model) =
             ( { model | setting = { setting | showHour = not setting.showHour } }
             , setQueryString <| urlFromSetting { setting | showHour = not setting.showHour }
             )
-
-        LinkClicked urlRequest ->
-            case urlRequest of
-                Browser.Internal url ->
-                    ( model, Browser.Navigation.load (Url.toString url) )
-
-                Browser.External href ->
-                    ( model, Browser.Navigation.load href )
 
         NoOp ->
             ( model, Cmd.none )

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,7 +165,7 @@ chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@^3.5.3:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -632,6 +632,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+immutable@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
+  integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -1007,6 +1012,15 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass@^1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.56.1.tgz#94d3910cd468fd075fa87f5bb17437a0b617d8a7"
+  integrity sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 semver@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -1036,7 +1050,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-source-map-js@^1.0.2:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==


### PR DESCRIPTION
これまで `Browser.application` を使ってURLのクエリ文字列の変更を行っていたが、 `/about` へのリンクを作ったときに `LinkClicked` をわざわざ実装して管理することになり、その必要があるのか？と思い始めたのでElmとして管理すべき対象を絞ってみた。

- header, footer は `index.html` に静的に記載すれば良い。
- となると、 title などは管理しなくて良いので `Browser.document` でもなく `Browser.element` でよい。
- クエリ文字列の初回読み込み、クエリ文字列の変更に関しては `js/index.js` の責務とする。

