### PR TITLE
カウントダウンをプログレスバーで表示可能にする

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -30,7 +30,7 @@ body > main {
   font-family: "D-DIN-bold";
   font-size: 5rem;
   text-align: center;
-  padding: 3rem 0;
+  padding: 4rem 0;
   margin: 1rem 0;
 
   &.greenback {
@@ -38,6 +38,17 @@ body > main {
   }
   &.blueback {
     background-color: #0000ff;
+  }
+
+  .digits {
+    display: inline-block;
+    line-height: 0.8;
+
+    .progress {
+      height: 10px;
+      border-radius: 3px;
+      float: right;
+    }
   }
 
   .digit {

--- a/js/index.js
+++ b/js/index.js
@@ -26,7 +26,8 @@ const parseParams = () => {
     fg: parseFg(searchParams.get("fg")),
     bg: searchParams.get("bg"),
     init: parseInit(searchParams.get("init")),
-    h: searchParams.get("h")
+    h: searchParams.get("h"),
+    p: searchParams.get("p")
   };
 };
 


### PR DESCRIPTION
`<progress>` のカラー設定が非標準（[参考](https://developer.mozilla.org/ja/docs/Web/CSS/::-webkit-progress-value)）なので、自前で作ってみることにする。

![synctimer-progress](https://user-images.githubusercontent.com/611276/205449570-624aa359-edb1-43c0-b22c-49c00ed9a8af.gif)
