### PR TITLE
Add Serif font

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -27,7 +27,6 @@ body > main {
 }
 
 .timer {
-  font-family: "D-DIN-bold";
   font-size: 5rem;
   text-align: center;
   padding: 4rem 0;
@@ -54,11 +53,17 @@ body > main {
   .digit {
     display: inline-block;
     width: 1ex;
-    vertical-align: middle;
   }
   .sep {
     display: inline-block;
-    width: 0.5ex;
+  }
+}
+
+.timer.d-din-bold {
+  font-family: "D-DIN-bold";
+
+  .sep {
+    vertical-align: text-top;
   }
 }
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Lora&display=swap&text=-:.0123456789");
+
 /*
   elm-hot creates an additional div wrapper around the app to make HMR possible.
   This could break styling in development mode if you are using Elm UI.
@@ -50,10 +52,7 @@ body > main {
     }
   }
 
-  .digit {
-    display: inline-block;
-    width: 1ex;
-  }
+  .digit,
   .sep {
     display: inline-block;
   }
@@ -62,8 +61,19 @@ body > main {
 .timer.d-din-bold {
   font-family: "D-DIN-bold";
 
+  .digit {
+    width: 1ex;
+  }
   .sep {
     vertical-align: text-top;
+  }
+}
+
+.timer.lora {
+  font-family: "Lora";
+
+  .digit {
+    width: 1.15ex;
   }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -25,6 +25,7 @@ const parseParams = () => {
   return {
     fg: parseFg(searchParams.get("fg")),
     bg: searchParams.get("bg"),
+    ff: searchParams.get("ff"),
     init: parseInit(searchParams.get("init")),
     h: searchParams.get("h"),
     p: searchParams.get("p")

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -21,16 +21,30 @@ type alias Model =
 type alias Setting =
     { bgColor : BgColor
     , fgColor : String
+    , fgFont : FgFont
     , initialTimeSeconds : Int
     , showHour : Bool
     , showProgress : Bool
     }
 
 
+settingToDict : Setting -> Dict.Dict String String
+settingToDict setting =
+    Dict.fromList
+        [ ( "fg", setting.fgColor )
+        , ( "bg", setting.bgColor |> encodeBgColor )
+        , ( "ff", setting.fgFont |> encodeFgFont )
+        , ( "init", setting.initialTimeSeconds |> String.fromInt )
+        , ( "h", setting.showHour |> encodeBoolean )
+        , ( "p", setting.showProgress |> encodeBoolean )
+        ]
+
+
 defaultSetting : Setting
 defaultSetting =
     { fgColor = "#415462"
     , bgColor = GreenBack
+    , fgFont = DDinBold
     , initialTimeSeconds = -10
     , showHour = True
     , showProgress = False
@@ -58,10 +72,35 @@ millisToDisplayTime t =
     }
 
 
+type FgFont
+    = DDinBold
+    | Lora
+
+
+encodeFgFont : FgFont -> String
+encodeFgFont fgFont =
+    case fgFont of
+        DDinBold ->
+            "d-din-bold"
+
+        Lora ->
+            "lora"
+
+
 type BgColor
     = Transparent
     | GreenBack
     | BlueBack
+
+
+dictFgFont : Dict.Dict String FgFont
+dictFgFont =
+    List.foldl (\bg -> Dict.insert (encodeFgFont bg) bg) Dict.empty [ DDinBold, Lora ]
+
+
+decodeFgFont : String -> Maybe FgFont
+decodeFgFont =
+    flip Dict.get dictFgFont
 
 
 encodeBgColor : BgColor -> String
@@ -109,6 +148,7 @@ decodeBoolean =
 type alias SettingFromQuery =
     { fg : Maybe String
     , bg : Maybe String
+    , ff : Maybe String
     , init : Maybe Int
     , h : Maybe String
     , p : Maybe String
@@ -124,6 +164,7 @@ parseSettingFromQuery : SettingFromQuery -> Setting
 parseSettingFromQuery setting =
     { fgColor = setting.fg |> Maybe.withDefault defaultSetting.fgColor
     , bgColor = setting.bg |> Maybe.andThen decodeBgColor |> Maybe.withDefault defaultSetting.bgColor
+    , fgFont = setting.ff |> Maybe.andThen decodeFgFont |> Maybe.withDefault defaultSetting.fgFont
     , initialTimeSeconds = setting.init |> Maybe.withDefault defaultSetting.initialTimeSeconds
     , showHour = setting.h |> Maybe.andThen decodeBoolean |> Maybe.withDefault defaultSetting.showHour
     , showProgress = setting.p |> Maybe.andThen decodeBoolean |> Maybe.withDefault defaultSetting.showProgress
@@ -160,15 +201,30 @@ type Msg
     | NoOp
 
 
+defaultSettingDict : Dict.Dict String String
+defaultSettingDict =
+    settingToDict defaultSetting
+
+
+isNotDefault : String -> String -> Bool
+isNotDefault key value =
+    Dict.get key defaultSettingDict
+        |> Maybe.map ((==) value >> not)
+        |> Maybe.withDefault False
+
+
+diffSettingDict : Setting -> Dict.Dict String String
+diffSettingDict setting =
+    settingToDict setting
+        |> Dict.filter isNotDefault
+
+
 urlFromSetting : Setting -> String
 urlFromSetting setting =
-    UB.toQuery
-        [ UB.string "fg" setting.fgColor
-        , UB.string "bg" <| encodeBgColor setting.bgColor
-        , UB.int "init" setting.initialTimeSeconds
-        , UB.string "h" <| encodeBoolean setting.showHour
-        , UB.string "p" <| encodeBoolean setting.showProgress
-        ]
+    diffSettingDict setting
+        |> Dict.toList
+        |> List.map (\( k, v ) -> UB.string k v)
+        |> UB.toQuery
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -196,6 +196,7 @@ type Msg
     | FastForwardSec Int
     | SetBgColor BgColor
     | SetFgColor String
+    | SetFgFont FgFont
     | ToggleShowHour
     | ToggleShowProgress
     | NoOp
@@ -269,6 +270,11 @@ update msg ({ setting } as model) =
             , setQueryString <| urlFromSetting { setting | fgColor = fgColor }
             )
 
+        SetFgFont fgFont ->
+            ( { model | setting = { setting | fgFont = fgFont } }
+            , setQueryString <| urlFromSetting { setting | fgFont = fgFont }
+            )
+
         ToggleShowHour ->
             ( { model | setting = { setting | showHour = not setting.showHour } }
             , setQueryString <| urlFromSetting { setting | showHour = not setting.showHour }
@@ -312,7 +318,7 @@ viewTimerDigits millis setting =
             else
                 [ displayTime.minutes, displayTime.seconds ]
     in
-    div [ class "timer", class "d-din-bold", timerBgColorClass setting.bgColor, style "color" setting.fgColor ]
+    div [ class "timer", fontClass setting.fgFont, timerBgColorClass setting.bgColor, style "color" setting.fgColor ]
         [ div [ class "digits" ] <|
             (List.concat <|
                 [ [ span (styleTimerSign displayTime.isMinus) [ text "-" ] ]
@@ -321,6 +327,16 @@ viewTimerDigits millis setting =
             )
                 ++ viewProgressBar millis setting
         ]
+
+
+fontClass : FgFont -> Html.Attribute Msg
+fontClass font =
+    case font of
+        DDinBold ->
+            class "d-din-bold"
+
+        Lora ->
+            class "lora"
 
 
 progress : Int -> Int -> String
@@ -481,8 +497,9 @@ viewTimerSettings setting =
         [ summary [] [ text "表示設定" ]
         , div [ class "grid" ]
             [ viewFgColorInput setting.fgColor
-            , viewBgColorInput setting.bgColor
+            , viewFgFontInput setting.fgFont
             ]
+        , viewBgColorInput setting.bgColor
         , div
             [ class "grid" ]
             [ label [ for "showHour" ]
@@ -513,6 +530,22 @@ viewFgColorInput fgColor =
                 ]
             ]
         ]
+
+
+viewFgFontInput : FgFont -> Html Msg
+viewFgFontInput font =
+    div []
+        [ label [ for "fgFont" ] [ text "フォント" ]
+        , select [ id "fgFont", onInput selectFgFont ]
+            [ option [ value <| encodeFgFont DDinBold, selected <| font == DDinBold ] [ text "D-DIN bold (Sans Serif)" ]
+            , option [ value <| encodeFgFont Lora, selected <| font == Lora ] [ text "Lora (Serif)" ]
+            ]
+        ]
+
+
+selectFgFont : String -> Msg
+selectFgFont =
+    decodeFgFont >> Maybe.withDefault DDinBold >> SetFgFont
 
 
 viewBgColorInput : BgColor -> Html Msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -256,7 +256,7 @@ viewTimerDigits millis setting =
             else
                 [ displayTime.minutes, displayTime.seconds ]
     in
-    div [ class "timer", timerBgColorClass setting.bgColor, style "color" setting.fgColor ]
+    div [ class "timer", class "d-din-bold", timerBgColorClass setting.bgColor, style "color" setting.fgColor ]
         [ div [ class "digits" ] <|
             (List.concat <|
                 [ [ span (styleTimerSign displayTime.isMinus) [ text "-" ] ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -48,6 +48,7 @@ settingFromQueryTest =
             \_ ->
                 { fg = Nothing
                 , bg = Nothing
+                , ff = Nothing
                 , init = Nothing
                 , h = Nothing
                 , p = Nothing
@@ -58,6 +59,7 @@ settingFromQueryTest =
             \_ ->
                 { fg = Just "#ffffff"
                 , bg = Just "bb"
+                , ff = Just "lora"
                 , init = Just -5
                 , h = Just "false"
                 , p = Just "true"
@@ -66,6 +68,7 @@ settingFromQueryTest =
                     |> Expect.equal
                         { fgColor = "#ffffff"
                         , bgColor = BlueBack
+                        , fgFont = Lora
                         , initialTimeSeconds = -5
                         , showHour = False
                         , showProgress = True
@@ -74,16 +77,18 @@ settingFromQueryTest =
             \_ ->
                 { fg = Just "#000000"
                 , bg = Nothing
+                , ff = Just "lora"
                 , init = Just -30
                 , h = Nothing
                 , p = Nothing
                 }
                     |> parseSettingFromQuery
-                    |> Expect.equal { defaultSetting | fgColor = "#000000", initialTimeSeconds = -30 }
+                    |> Expect.equal { defaultSetting | fgColor = "#000000", initialTimeSeconds = -30, fgFont = Lora }
         , test "with some correct enums" <|
             \_ ->
                 { fg = Nothing
                 , bg = Just "tp"
+                , ff = Nothing
                 , init = Nothing
                 , h = Just "true"
                 , p = Just "true"
@@ -94,6 +99,7 @@ settingFromQueryTest =
             \_ ->
                 { fg = Nothing
                 , bg = Just "aa"
+                , ff = Just "bb"
                 , init = Nothing
                 , h = Just "test"
                 , p = Just "hogehoge"


### PR DESCRIPTION
セリフ体のフォントを選択できるようにする。
今回は Lora を追加してみた。
https://fonts.google.com/specimen/Lora
![Cursor_と_Sync_Timer_-_同時視聴用タイマー](https://user-images.githubusercontent.com/611276/219409258-16c6579f-0451-437a-b85e-3462133cdcca.png)

## 追加要素

設定項目が多くなってクエリ文字列が長くなってきたので、デフォルトの設定と異なる部分のみをクエリ文字列にするように変更した。
