### PR TITLE
Change input form for reset time.

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -144,3 +144,33 @@ button .button-icon {
 dialog article {
   max-width: 95%;
 }
+
+.ff-buttons {
+  display: flex;
+  justify-content: space-between;
+  button {
+    width: 49%;
+  }
+}
+
+.reset-form {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  label {
+    display: block;
+    margin: 0;
+  }
+}
+
+input.reset-form-time {
+  width: auto;
+  margin: 0 1ex;
+}
+
+button.reset-form-button {
+  width: auto;
+  margin: 0;
+  flex-grow: 1;
+}

--- a/elm.json
+++ b/elm.json
@@ -11,6 +11,7 @@
             "elm/core": "1.0.4",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0"
         },

--- a/js/index.js
+++ b/js/index.js
@@ -17,7 +17,7 @@ const parseParams = () => {
   const parseInit = (s) => {
     if (s) {
       const n = parseInt(s, 10);
-      if (n > 30 || n < -30) return null;
+      if (isNaN(n)) return null;
       return n;
     }
     return null;

--- a/src/View.elm
+++ b/src/View.elm
@@ -1,4 +1,4 @@
-module View exposing (DisplayTime, millisToDisplayTime, selectBgColor, selectFgFont, view)
+module View exposing (DisplayTime, ResetTimeValue, millisToDisplayTime, resetTimeValueParser, resetTimeValueToString, selectBgColor, selectFgFont, view)
 
 import Html exposing (Attribute, Html, a, button, details, div, i, input, label, option, select, span, summary, text)
 import Html.Attributes exposing (attribute, checked, class, for, id, selected, size, step, style, type_, value)
@@ -214,7 +214,7 @@ fastForwardButton =
 
 type alias ResetTime =
     { isMinus : Bool
-    , timeValue : String
+    , timeValue : ResetTimeValue
     }
 
 
@@ -243,6 +243,15 @@ resetTimeValueParser =
         |= zeroPadIntParser
 
 
+resetTimeValueToString : ResetTimeValue -> String
+resetTimeValueToString value =
+    (String.padLeft 2 '0' <| String.fromInt value.hours)
+        ++ ":"
+        ++ (String.padLeft 2 '0' <| String.fromInt value.minutes)
+        ++ ":"
+        ++ (String.padLeft 2 '0' <| String.fromInt value.seconds)
+
+
 initialTimeToResetTime : Int -> ResetTime
 initialTimeToResetTime initialTimeSeconds =
     let
@@ -250,16 +259,20 @@ initialTimeToResetTime initialTimeSeconds =
             abs initialTimeSeconds
 
         hours =
-            absSeconds // 3600 |> String.fromInt |> String.padLeft 2 '0'
+            absSeconds // 3600
 
         minutes =
-            absSeconds // 60 |> modBy 60 |> String.fromInt |> String.padLeft 2 '0'
+            absSeconds // 60 |> modBy 60
 
         seconds =
-            absSeconds |> modBy 60 |> String.fromInt |> String.padLeft 2 '0'
+            absSeconds |> modBy 60
     in
     { isMinus = initialTimeSeconds < 0
-    , timeValue = hours ++ ":" ++ minutes ++ ":" ++ seconds
+    , timeValue =
+        { hours = hours
+        , minutes = minutes
+        , seconds = seconds
+        }
     }
 
 
@@ -300,7 +313,7 @@ resetForm initialTimeSeconds =
             [ input [ id "reset-is-minus", type_ "checkbox", checked resetTime.isMinus, onCheck <| updateResetTimeMinus initialTimeSeconds ] []
             , text "マイナス"
             ]
-        , input [ type_ "time", value resetTime.timeValue, step "1", size 8, class "reset-form-time", onInput <| updateResetTimeValue resetTime.isMinus ] []
+        , input [ type_ "time", value <| resetTimeValueToString resetTime.timeValue, step "1", size 8, class "reset-form-time", onInput <| updateResetTimeValue resetTime.isMinus ] []
         , button [ class "contrast", class "reset-form-button", onClick Reset ]
             [ i [ class "fas", class "fa-backward-fast", class "button-icon" ] [], text "リセット" ]
         ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -1,10 +1,11 @@
 module View exposing (DisplayTime, millisToDisplayTime, selectBgColor, selectFgFont, view)
 
 import Html exposing (Attribute, Html, a, button, details, div, i, input, label, option, select, span, summary, text)
-import Html.Attributes as A exposing (attribute, checked, class, for, id, selected, step, style, type_, value)
-import Html.Events exposing (onClick, onInput)
+import Html.Attributes exposing (attribute, checked, class, for, id, selected, size, step, style, type_, value)
+import Html.Events exposing (onCheck, onClick, onInput)
 import Model exposing (BgColor(..), FgFont(..), Model, Setting, decodeBgColor, decodeFgFont, encodeBgColor, encodeFgFont)
 import Msg exposing (Msg(..))
+import Parser exposing ((|.), (|=))
 
 
 type alias DisplayTime =
@@ -170,12 +171,11 @@ viewTimerControls : Model -> Html Msg
 viewTimerControls model =
     div [ class "controls" ]
         [ div [] [ startPauseButton model.paused ]
-        , div [ class "grid" ]
-            [ div [] [ rewindButton ]
-            , div [] [ fastForwardButton ]
+        , div [ class "ff-buttons" ]
+            [ rewindButton
+            , fastForwardButton
             ]
-        , div [] [ resetButton model.setting.initialTimeSeconds ]
-        , div [] [ initialTimeSlider model.setting.initialTimeSeconds ]
+        , div [] [ resetForm model.setting.initialTimeSeconds ]
         ]
 
 
@@ -212,11 +212,97 @@ fastForwardButton =
         ]
 
 
-resetButton : Int -> Html Msg
-resetButton initialTimeSeconds =
-    button [ class "contrast", onClick Reset ]
-        [ i [ class "fas", class "fa-backward-fast", class "button-icon" ] []
-        , text <| String.fromInt initialTimeSeconds ++ " 秒にリセット"
+type alias ResetTime =
+    { isMinus : Bool
+    , timeValue : String
+    }
+
+
+type alias ResetTimeValue =
+    { hours : Int
+    , minutes : Int
+    , seconds : Int
+    }
+
+
+zeroPadIntParser : Parser.Parser Int
+zeroPadIntParser =
+    Parser.oneOf
+        [ Parser.succeed identity |. Parser.chompIf ((==) '0') |= Parser.int
+        , Parser.int
+        ]
+
+
+resetTimeValueParser : Parser.Parser ResetTimeValue
+resetTimeValueParser =
+    Parser.succeed ResetTimeValue
+        |= zeroPadIntParser
+        |. Parser.symbol ":"
+        |= zeroPadIntParser
+        |. Parser.symbol ":"
+        |= zeroPadIntParser
+
+
+initialTimeToResetTime : Int -> ResetTime
+initialTimeToResetTime initialTimeSeconds =
+    let
+        absSeconds =
+            abs initialTimeSeconds
+
+        hours =
+            absSeconds // 3600 |> String.fromInt |> String.padLeft 2 '0'
+
+        minutes =
+            absSeconds // 60 |> modBy 60 |> String.fromInt |> String.padLeft 2 '0'
+
+        seconds =
+            absSeconds |> modBy 60 |> String.fromInt |> String.padLeft 2 '0'
+    in
+    { isMinus = initialTimeSeconds < 0
+    , timeValue = hours ++ ":" ++ minutes ++ ":" ++ seconds
+    }
+
+
+negateIf : Bool -> Int -> Int
+negateIf isMinus value =
+    if isMinus then
+        negate value
+
+    else
+        value
+
+
+updateResetTimeMinus : Int -> Bool -> Msg
+updateResetTimeMinus initialTimeSeconds isMinus =
+    abs initialTimeSeconds
+        |> negateIf isMinus
+        |> UpdateResetTime
+
+
+updateResetTimeValue : Bool -> String -> Msg
+updateResetTimeValue isMinus timeValue =
+    Parser.run resetTimeValueParser timeValue
+        |> Result.toMaybe
+        |> Maybe.map (\t -> t.hours * 3600 + t.minutes * 60 + t.seconds)
+        |> Maybe.map (negateIf isMinus)
+        |> Maybe.map UpdateResetTime
+        |> Maybe.withDefault NoOp
+
+
+resetForm : Int -> Html Msg
+resetForm initialTimeSeconds =
+    let
+        resetTime =
+            initialTimeToResetTime initialTimeSeconds
+    in
+    div [ class "reset-form" ]
+        [ label [ for "reset-is-minus", class "reset-form-minus" ]
+            [ input [ id "reset-is-minus", type_ "checkbox", checked resetTime.isMinus, onCheck <| updateResetTimeMinus initialTimeSeconds ] []
+            , text "マイナス"
+            ]
+        , input [ type_ "time", value resetTime.timeValue, step "1", size 8, class "reset-form-time", onInput <| updateResetTimeValue resetTime.isMinus ] []
+        , button [ class "contrast", class "reset-form-button", onClick Reset ]
+            [ i [ class "fas", class "fa-backward-fast", class "button-icon" ] [], text "リセット" ]
         ]
 
 
@@ -297,24 +383,3 @@ viewBgColorInput bgColor =
 selectBgColor : String -> Msg
 selectBgColor =
     decodeBgColor >> Maybe.map SetBgColor >> Maybe.withDefault NoOp
-
-
-initialTimeSlider : Int -> Html Msg
-initialTimeSlider initialTimeSeconds =
-    div [ class "delay-slider" ]
-        [ input
-            [ type_ "range"
-            , A.min "-30"
-            , A.max "30"
-            , step "1"
-            , onInput (String.toInt >> Maybe.withDefault 0 >> UpdateResetTime)
-            , value <| String.fromInt initialTimeSeconds
-            , tooltip <| "タイマーの開始時間: " ++ String.fromInt initialTimeSeconds ++ "秒"
-            ]
-            []
-        ]
-
-
-tooltip : String -> Attribute Msg
-tooltip =
-    attribute "data-tooltip"


### PR DESCRIPTION
The slider was a simple way to easily set the range from -30 seconds to 30 seconds, but was not suitable if you wanted to reset the time from 30 minutes. In this update, we have tried to accommodate various demands by specifying the time directly in the input.

Closes #72 