### PR TITLE
Customize grid breakpoint.

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -1,3 +1,8 @@
+// Use pico v1 lg viewport as md.
+@use "@picocss/pico/scss/pico" with (
+  $breakpoints: ( md: (breakpoint: 970px, viewport: 960px ))
+);
+
 /*
   elm-hot creates an additional div wrapper around the app to make HMR possible.
   This could break styling in development mode if you are using Elm UI.

--- a/js/common.js
+++ b/js/common.js
@@ -1,4 +1,3 @@
-import "@picocss/pico/css/pico.css";
 import "@fortawesome/fontawesome-free/css/fontawesome.css";
 import "@fortawesome/fontawesome-free/css/brands.css";
 import "@fortawesome/fontawesome-free/css/solid.css";


### PR DESCRIPTION
PicoCSSのgridのブレークポイントがv2で変更されていたためレイアウト崩れが発生していた。
暫定対応としてbreakpoint, viewportの値を変更した。
ただ、Sassの警告が出ている。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced styling with Pico CSS, improving responsiveness at various viewport sizes.
	- Added a function to parse URL search parameters for better integration with the application.
	- Streamlined initialization of the Elm application with parsed parameters.
  
- **Bug Fixes**
	- Improved handling of URL parameters to ensure accurate parsing and application behavior.

- **Documentation**
	- Maintained comments for context on styling and font usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->